### PR TITLE
Implement cost filtering with text input

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -39,8 +39,8 @@ export function nullifyParseInt(value: string | null | undefined): number | unde
   return v;
 }
 
-export function parseRange(input: string | undefined): number[] {
-  if (!input) return [];
+export function parseRange(input: string | undefined): number[] | undefined {
+  if (!input) return undefined;
 
   const result: number[] = [];
 

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -7,9 +7,9 @@ export function cn(...inputs: ClassValue[]) {
 
 
 export function ordinal(n: number) {
-  const s = ["th","st","nd","rd"];
-  const v = n%100;
-  return n+(s[(v-20)%10]||s[v]||s[0]);
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
 // Map a value if it's not null or undefined, or an empty array
@@ -31,12 +31,36 @@ export function nullifyTrim(value: string | null | undefined): string | undefine
   return v;
 }
 
-export function nullifyParseInt(value: string | null | undefined): number | null {
+export function nullifyParseInt(value: string | null | undefined): number | undefined {
   const t = nullifyTrim(value);
-  if (t == null) { return null }
+  if (t == null) { return undefined }
   const v = parseInt(t, 10);
-  if (isNaN(v)) { return null }
+  if (isNaN(v)) { return undefined }
   return v;
+}
+
+export function parseRange(input: string | undefined): number[] {
+  if (!input) return [];
+
+  const result: number[] = [];
+
+  input.split(',').forEach(part => {
+    if (part.includes('-')) {
+      const [start, end] = part.split('-').map(Number);
+      if (!isNaN(start) && !isNaN(end)) {
+        for (let i = start; i <= end; i++) {
+          result.push(i);
+        }
+      }
+    } else {
+      const num = Number(part);
+      if (!isNaN(num)) {
+        result.push(num);
+      }
+    }
+  });
+
+  return result;
 }
 
 export function ifNotZero<U>(value: number | null | undefined, mapF: (value: number) => U): U | null {
@@ -71,7 +95,7 @@ export function toMap<T, K extends keyof any>(arr: T[], keyFn: (t: T) => K): Rec
 }
 
 export function formatOrdinal(n: number): string {
-  const s = ["th","st","nd","rd"];
-  const v = n%100;
-  return n+(s[(v-20)%10]||s[v]||s[0]);
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }

--- a/app/loaders/search.ts
+++ b/app/loaders/search.ts
@@ -13,6 +13,8 @@ export interface SearchQuery {
   triggerPart?: string;
   conditionPart?: string;
   effectPart?: string;
+  mainCosts: number[];
+  recallCosts: number[];
 }
 
 export interface PageParams {
@@ -91,7 +93,7 @@ export interface SearchResults {
 }
 
 export async function search(searchQuery: SearchQuery, pageParams: PageParams): Promise<SearchResults> {
-  const { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart } = searchQuery
+  const { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart, mainCosts, recallCosts } = searchQuery
   const { page, includePagination } = pageParams
 
   if (faction == null && characterName == null && mainEffect == null && triggerPart == null && conditionPart == null && effectPart == null) {
@@ -143,6 +145,22 @@ export async function search(searchQuery: SearchQuery, pageParams: PageParams): 
         some: {
           AND: mainAbilitySearchParams
         }
+      }
+    })
+  }
+
+  if (mainCosts.length > 0) {
+    searchParams.push({
+      mainCost: {
+        in: mainCosts
+      }
+    })
+  }
+
+  if (recallCosts.length > 0) {
+    searchParams.push({
+      recallCost: {
+        in: recallCosts
       }
     })
   }

--- a/app/loaders/search.ts
+++ b/app/loaders/search.ts
@@ -13,8 +13,8 @@ export interface SearchQuery {
   triggerPart?: string;
   conditionPart?: string;
   effectPart?: string;
-  mainCosts: number[];
-  recallCosts: number[];
+  mainCosts?: number[];
+  recallCosts?: number[];
 }
 
 export interface PageParams {
@@ -149,7 +149,7 @@ export async function search(searchQuery: SearchQuery, pageParams: PageParams): 
     })
   }
 
-  if (mainCosts.length > 0) {
+  if (mainCosts) {
     searchParams.push({
       mainCost: {
         in: mainCosts
@@ -157,7 +157,7 @@ export async function search(searchQuery: SearchQuery, pageParams: PageParams): 
     })
   }
 
-  if (recallCosts.length > 0) {
+  if (recallCosts) {
     searchParams.push({
       recallCost: {
         in: recallCosts

--- a/app/loaders/search.ts
+++ b/app/loaders/search.ts
@@ -150,19 +150,35 @@ export async function search(searchQuery: SearchQuery, pageParams: PageParams): 
   }
 
   if (mainCosts) {
-    searchParams.push({
-      mainCost: {
-        in: mainCosts
-      }
-    })
+    if (mainCosts.length == 1) {
+      searchParams.push({
+        mainCost: {
+          equals: mainCosts[0]
+        }
+      })
+    } else {
+      searchParams.push({
+        mainCost: {
+          in: mainCosts
+        }
+      })
+    }
   }
 
   if (recallCosts) {
-    searchParams.push({
-      recallCost: {
-        in: recallCosts
-      }
-    })
+    if (recallCosts.length == 1) {
+      searchParams.push({
+        recallCost: {
+          equals: recallCosts[0]
+        }
+      })
+    } else {
+      searchParams.push({
+        recallCost: {
+          in: recallCosts
+        }
+      })
+    }
   }
 
   const whereClause: UniqueInfoWhereInput = {

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -6,7 +6,7 @@ import { FactionSelect } from "~/components/altered/FactionSelect";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { nullifyParseInt, nullifyTrim } from "~/lib/utils";
+import { nullifyParseInt, nullifyTrim, parseRange } from "~/lib/utils";
 import { ResultGrid } from "~/components/altered/ResultGrid";
 import { ResultsPagination } from "~/components/common/pagination";
 
@@ -19,18 +19,23 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const triggerPart = nullifyTrim(url.searchParams.get("tr"));
   const conditionPart = nullifyTrim(url.searchParams.get("cond"));
   const effectPart = nullifyTrim(url.searchParams.get("eff"));
+  const mainCostRange = nullifyTrim(url.searchParams.get("mc"));
+  const recallCostRange = nullifyTrim(url.searchParams.get("rc"));
 
   const currentPage = nullifyParseInt(url.searchParams.get("p")) ?? 1;
 
+  const mainCosts = parseRange(mainCostRange)
+  const recallCosts = parseRange(recallCostRange)
+
   const { results, pagination } = await search(
-    { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart },
+    { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart, mainCosts, recallCosts },
     { page: currentPage, includePagination: true }
   );
 
   return {
     results,
     pagination: { ...pagination, currentPage },
-    query: { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart },
+    query: { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart, mainCostRange, recallCostRange },
   };
 }
 
@@ -41,7 +46,7 @@ export default function SearchPage() {
   const now = useMemo(() => new Date(), []);
 
   // Safely destructure with default values
-  const { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart } = loaderData?.query ?? {};
+  const { faction, characterName, mainEffect, triggerPart, conditionPart, effectPart, mainCostRange, recallCostRange } = loaderData?.query ?? {};
   const results = loaderData.results
   const pagination = loaderData.pagination
 
@@ -75,6 +80,24 @@ export default function SearchPage() {
                 name="cname"
                 defaultValue={characterName ?? ""}
                 placeholder="Character name"
+              />
+            </div>
+            <div>
+              <Label htmlFor="mc">Hand cost</Label>
+              <Input
+                type="text"
+                name="mc"
+                defaultValue={mainCostRange ?? ""}
+                placeholder="1-3"
+              />
+            </div>
+            <div>
+              <Label htmlFor="rc">Reserve cost</Label>
+              <Input
+                type="text"
+                name="rc"
+                defaultValue={recallCostRange ?? ""}
+                placeholder="4,6"
               />
             </div>
           </div>


### PR DESCRIPTION
After our conversation I've included filtering based on card cost from hand and reserve. The accepted input is in the format of:

* `A` to search for cards of cost `A`.
* `X-Y` to search for cards with cost in the range between `X` and `Y` inclusive.

Multiple filters can be applied if separated by `,`. The filter `1-3,5` will search for cards with cost `1`, `2`, `3` or `5`.

Currently this filter is being applied with an `in` clause. It'd be better if we could use ranges in an indexed field, but I don't really expect the array to grow much bigger than a few elements so we can let the db do the heavy lifting (for the time being).